### PR TITLE
nrfx_uart: Adding pulldown on CTS pin

### DIFF
--- a/drivers/src/nrfx_uart.c
+++ b/drivers/src/nrfx_uart.c
@@ -89,7 +89,7 @@ static void apply_config(nrfx_uart_t        const * p_instance,
     {
         if (p_config->pselcts != NRF_UART_PSEL_DISCONNECTED)
         {
-            nrf_gpio_cfg_input(p_config->pselcts, NRF_GPIO_PIN_NOPULL);
+            nrf_gpio_cfg_input(p_config->pselcts, NRF_GPIO_PIN_PULLDOWN);
         }
         if (p_config->pselrts != NRF_UART_PSEL_DISCONNECTED)
         {


### PR DESCRIPTION
Problem occurs regularly on Linux system, that Segger on development
kits does not accept receiving characters on the serial USB.
One workaround seems to be to ground the CTS pin.

This patch tries to solve this problem by setting a pull down on the
pin in software instead.