### PR TITLE
Throw an error when the current chip variant is unknown

### DIFF
--- a/mdk/nrf_peripherals.h
+++ b/mdk/nrf_peripherals.h
@@ -46,6 +46,8 @@
     #include "nrf52832_peripherals.h"
 #elif defined(NRF52840_XXAA)
     #include "nrf52840_peripherals.h"
+#else
+    #error Unknown chip variant
 #endif
 
 /*lint --flb "Leave library region" */


### PR DESCRIPTION
To avoid hard to diagnose issues (lots of undefined macros), clearly throw an error when the current chip cannot be determined.