### PR TITLE
nrfx_adc: Remove deprecated assertion

### DIFF
--- a/drivers/include/nrfx_adc.h
+++ b/drivers/include/nrfx_adc.h
@@ -182,8 +182,7 @@ void nrfx_adc_uninit(void);
  * called, all channels that have been enabled with this function are sampled.
  *
  * @note The channel instance variable @p p_channel is used by the driver as an item
- *       in a list. Therefore, it cannot be an automatic variable, and an assertion fails if it is
- *       an automatic variable (if asserts are enabled).
+ *       in a list. Therefore, it cannot be an automatic variable that is located on the stack.
  */
 void nrfx_adc_channel_enable(nrfx_adc_channel_t * const p_channel);
 

--- a/drivers/src/nrfx_adc.c
+++ b/drivers/src/nrfx_adc.c
@@ -94,7 +94,6 @@ void nrfx_adc_uninit(void)
 
 void nrfx_adc_channel_enable(nrfx_adc_channel_t * const p_channel)
 {
-    NRFX_ASSERT(!is_address_from_stack(p_channel));
     NRFX_ASSERT(!nrfx_adc_is_busy());
 
     p_channel->p_next = NULL;


### PR DESCRIPTION
Commit removes line with deprecated and no longer supported assertion in
nrfx_adc driver. Documentation is aligned to this change to provide clear
information.