### PR TITLE
nrfx_spim: Fix Slave Select initialization

### DIFF
--- a/drivers/src/nrfx_spim.c
+++ b/drivers/src/nrfx_spim.c
@@ -263,6 +263,11 @@ nrfx_err_t nrfx_spim_init(nrfx_spim_t  const * const p_instance,
     }
     m_cb[p_instance->drv_inst_idx].miso_pin = p_config->miso_pin;
     // - Slave Select (optional) - output with initial value 1 (inactive).
+
+    // 'p_cb->ss_pin' variable is used during transfers to check if SS pin should be toggled,
+    // so this field needs to be initialized even if the pin is not used.
+    p_cb->ss_pin = p_config->ss_pin;
+
     if (p_config->ss_pin != NRFX_SPIM_PIN_NOT_USED)
     {
         if (p_config->ss_active_high)
@@ -285,7 +290,6 @@ nrfx_err_t nrfx_spim_init(nrfx_spim_t  const * const p_instance,
                                    p_config->ss_duration);
         }
 #endif
-        m_cb[p_instance->drv_inst_idx].ss_pin = p_config->ss_pin;
         m_cb[p_instance->drv_inst_idx].ss_active_high = p_config->ss_active_high;
     }
 

--- a/drivers/src/nrfx_spim.c
+++ b/drivers/src/nrfx_spim.c
@@ -261,7 +261,7 @@ nrfx_err_t nrfx_spim_init(nrfx_spim_t  const * const p_instance,
     {
         miso_pin = NRF_SPIM_PIN_NOT_CONNECTED;
     }
-    m_cb[p_instance->drv_inst_idx].miso_pin = p_config->miso_pin;
+    p_cb->miso_pin = p_config->miso_pin;
     // - Slave Select (optional) - output with initial value 1 (inactive).
 
     // 'p_cb->ss_pin' variable is used during transfers to check if SS pin should be toggled,
@@ -282,7 +282,7 @@ nrfx_err_t nrfx_spim_init(nrfx_spim_t  const * const p_instance,
 #if NRFX_CHECK(NRFX_SPIM_EXTENDED_ENABLED)
         if (p_config->use_hw_ss)
         {
-            m_cb[p_instance->drv_inst_idx].use_hw_ss = p_config->use_hw_ss;
+            p_cb->use_hw_ss = p_config->use_hw_ss;
             nrf_spim_csn_configure(p_spim,
                                    p_config->ss_pin,
                                    (p_config->ss_active_high == true ?
@@ -290,7 +290,7 @@ nrfx_err_t nrfx_spim_init(nrfx_spim_t  const * const p_instance,
                                    p_config->ss_duration);
         }
 #endif
-        m_cb[p_instance->drv_inst_idx].ss_active_high = p_config->ss_active_high;
+        p_cb->ss_active_high = p_config->ss_active_high;
     }
 
 #if NRFX_CHECK(NRFX_SPIM_EXTENDED_ENABLED)


### PR DESCRIPTION
Commit fixes situation when Slave Select is set as unused. Configuration
value was not assign to field in control block and slave select field's
value remained zero. It caused pin toggling during SPI transmission when
GPIO 0 is configured as output.