### PR TITLE
mdk: Fix compilation error for Clang

### DIFF
--- a/mdk/gcc_startup_nrf51.S
+++ b/mdk/gcc_startup_nrf51.S
@@ -164,7 +164,7 @@ Reset_Handler:
     ldr r2, =__data_start__
     ldr r3, =__bss_start__
 
-    subs r3, r2
+    subs r3, r3, r2
     ble .L_loop1_done
 
 .L_loop1:
@@ -191,7 +191,7 @@ Reset_Handler:
 
     movs r0, 0
 
-    subs r2, r1
+    subs r2, r2, r1
     ble .L_loop3_done
 
 .L_loop3:


### PR DESCRIPTION
Clang is almost compatible with GCC, but not entirely. Fix an assembly instruction to get this file to compile with Clang.