### PR TITLE
nrfx_twim: fix resuming TXRX transfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project are documented in this file.
 
+## [Unreleased]
+### Fixed
+- Fixed starting TWIM TXRX transfer after preceding transfer was without stop condition.
+
 ## [1.1.0] - 2018-06-15
 ### Added
 - Implemented workaround for nRF52832 and nRF52840 anomaly 194 in the I2S driver.

--- a/drivers/src/nrfx_twim.c
+++ b/drivers/src/nrfx_twim.c
@@ -373,6 +373,7 @@ __STATIC_INLINE nrfx_err_t twim_xfer(twim_control_block_t        * p_cb,
         nrf_twim_shorts_set(p_twim, NRF_TWIM_SHORT_LASTTX_STARTRX_MASK |
                                     NRF_TWIM_SHORT_LASTRX_STOP_MASK);
         p_cb->int_mask = NRF_TWIM_INT_STOPPED_MASK | NRF_TWIM_INT_ERROR_MASK;
+        nrf_twim_task_trigger(p_twim, NRF_TWIM_TASK_RESUME);
         break;
     case NRFX_TWIM_XFER_TX:
         nrf_twim_tx_buffer_set(p_twim, p_xfer_desc->p_primary_buf, p_xfer_desc->primary_length);


### PR DESCRIPTION
TXRX transfer was missing triggering RESUME task. When previous
transfer ended up without stop condition TWIM is in suspend state.
It is required to resume before starting next transfer.

Fixes #32 