### PR TITLE
nrfx_saadc: Fix 'unused variable err_code' compilation warning

### DIFF
--- a/drivers/src/nrfx_saadc.c
+++ b/drivers/src/nrfx_saadc.c
@@ -249,6 +249,7 @@ nrfx_err_t nrfx_saadc_init(nrfx_saadc_config_t const * p_config,
 void nrfx_saadc_uninit(void)
 {
     NRFX_ASSERT(m_cb.state != NRFX_DRV_STATE_UNINITIALIZED);
+    nrfx_err_t err_code;
 
     nrf_saadc_int_disable(NRF_SAADC_INT_ALL);
     NRFX_IRQ_DISABLE(SAADC_IRQn);
@@ -266,7 +267,7 @@ void nrfx_saadc_uninit(void)
     {
         if (m_cb.psel[channel].pselp != NRF_SAADC_INPUT_DISABLED)
         {
-            nrfx_err_t err_code = nrfx_saadc_channel_uninit(channel);
+            err_code = nrfx_saadc_channel_uninit(channel);
             NRFX_ASSERT(err_code == NRFX_SUCCESS);
         }
     }


### PR DESCRIPTION
This fixes compilation warning due to unused 'err_code' variable.

nrfx/drivers/src/nrfx_saadc.c: In function ‘nrfx_saadc_uninit’:
nrfx/drivers/src/nrfx_saadc.c:269:24: warning: unused variable ‘err_code’ [-Wunused-variable]
              nrfx_err_t err_code = nrfx_saadc_channel_uninit(channel);

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>