### PR TITLE
nrfx_saadc: Add channel enable/disable helper functions

### DIFF
--- a/drivers/include/nrfx_saadc.h
+++ b/drivers/include/nrfx_saadc.h
@@ -306,6 +306,28 @@ void nrfx_saadc_limits_set(uint8_t channel, int16_t limit_low, int16_t limit_hig
 
 void nrfx_saadc_irq_handler(void);
 
+/**
+ * @brief Function for enabling an SAADC channel
+ *
+ * @param chan  SAADC channel number
+ * @param pselp Input positive pin selection
+ * @param pseln Input negative pin selection
+ *
+ * @retval NRFX_SUCCESS    If the ADC driver is not busy.
+ * @retval NRFX_ERROR_BUSY If the ADC driver is busy.
+ */
+nrfx_err_t nrfx_saadc_channel_enable(int chan, nrf_saadc_input_t pselp,
+                                     nrf_saadc_input_t           pseln);
+
+/**
+ * @brief Function for disabling an SAADC channel
+ *
+ * @param chan  SAADC channel number
+ *
+ * @retval NRFX_SUCCESS    If the ADC driver is not busy.
+ * @retval NRFX_ERROR_BUSY If the ADC driver is busy.
+ */
+nrfx_err_t nrfx_saadc_channel_disable(int chan);
 
 /** @} */
 

--- a/drivers/src/nrfx_saadc.c
+++ b/drivers/src/nrfx_saadc.c
@@ -627,20 +627,48 @@ void nrfx_saadc_limits_set(uint8_t channel, int16_t limit_low, int16_t limit_hig
     }
 }
 
-void nrfx_enable_adc_chan(int chan, nrf_saadc_input_t   pselp,
-                          nrf_saadc_input_t             pseln)
+
+nrfx_err_t nrfx_saadc_channel_enable(int chan, nrf_saadc_input_t pselp,
+                                     nrf_saadc_input_t           pseln)
 {
+    nrfx_err_t err_code;
+
+    if (m_cb.adc_state != NRF_SAADC_STATE_IDLE)
+    {
+        err_code = NRFX_ERROR_BUSY;
+        NRFX_LOG_WARNING("Function: %s error code: %s.",
+                         __func__,
+                         NRFX_LOG_ERROR_STRING_GET(err_code));
+        return err_code;
+    }
+
+    NRFX_ASSERT(m_cb.state != NRFX_DRV_STATE_UNINITIALIZED);
     NRFX_ASSERT(m_cb.active_channels < NRF_SAADC_CHANNEL_COUNT);
     ++m_cb.active_channels;
     nrf_saadc_channel_input_set(chan, pselp, pseln);
+
+    return NRFX_SUCCESS;
 }
 
-void nrfx_disable_adc_chan(int chan)
+
+nrfx_err_t nrfx_saadc_channel_disable(int chan)
 {
+    nrfx_err_t err_code;
+
+    if (m_cb.adc_state != NRF_SAADC_STATE_IDLE)
+    {
+        err_code = NRFX_ERROR_BUSY;
+        NRFX_LOG_WARNING("Function: %s error code: %s.",
+                         __func__,
+                         NRFX_LOG_ERROR_STRING_GET(err_code));
+        return err_code;
+    }
+
     NRFX_ASSERT(m_cb.active_channels != 0);
     --m_cb.active_channels;
     nrf_saadc_channel_input_set(chan, NRF_SAADC_INPUT_DISABLED,
                                 NRF_SAADC_INPUT_DISABLED);
-}
 
+    return NRFX_SUCCESS;
+}
 #endif // NRFX_CHECK(NRFX_SAADC_ENABLED)

--- a/drivers/src/nrfx_saadc.c
+++ b/drivers/src/nrfx_saadc.c
@@ -626,4 +626,21 @@ void nrfx_saadc_limits_set(uint8_t channel, int16_t limit_low, int16_t limit_hig
         nrf_saadc_int_enable(int_mask);
     }
 }
+
+void nrfx_enable_adc_chan(int chan, nrf_saadc_input_t   pselp,
+                          nrf_saadc_input_t             pseln)
+{
+    NRFX_ASSERT(m_cb.active_channels < NRF_SAADC_CHANNEL_COUNT);
+    ++m_cb.active_channels;
+    nrf_saadc_channel_input_set(chan, pselp, pseln);
+}
+
+void nrfx_disable_adc_chan(int chan)
+{
+    NRFX_ASSERT(m_cb.active_channels != 0);
+    --m_cb.active_channels;
+    nrf_saadc_channel_input_set(chan, NRF_SAADC_INPUT_DISABLED,
+                                NRF_SAADC_INPUT_DISABLED);
+}
+
 #endif // NRFX_CHECK(NRFX_SAADC_ENABLED)


### PR DESCRIPTION
Purpose of this addition is to have SAADC channel enable and
disable functions that modify only the active channel count and
modify the PSELP/PSELN registers. This is not to address any
bugs; it is so that one can enable and disable the channels
without the need to reconfigure them (they can be configured once
and then simply enabled/disabled).