### PR TITLE
nrfx_uarte: Make uarte_control_block_t's tx_buffer_length volatile

### DIFF
--- a/drivers/src/nrfx_uarte.c
+++ b/drivers/src/nrfx_uarte.c
@@ -93,7 +93,7 @@ typedef struct
     uint8_t            const * p_tx_buffer;
     uint8_t                  * p_rx_buffer;
     uint8_t                  * p_rx_secondary_buffer;
-    size_t                     tx_buffer_length;
+    volatile size_t            tx_buffer_length;
     size_t                     rx_buffer_length;
     size_t                     rx_secondary_buffer_length;
     nrfx_drv_state_t           state;


### PR DESCRIPTION
In certain cases nrfx_uarte_tx_in_progress() needs to always return true. Such
behavior was observed when nrfx was compiled with strong optimizations (-O3).

Marking tx_buffer_length as volatile solved the problem.

Tested on Linux with arm-none-eabi-gcc v8.2.0