### PR TITLE
nrfx_uart: Declare tx_buffer_length to be volatile.

### DIFF
--- a/drivers/src/nrfx_uart.c
+++ b/drivers/src/nrfx_uart.c
@@ -58,7 +58,7 @@ typedef struct
     uint8_t           const * p_tx_buffer;
     uint8_t                 * p_rx_buffer;
     uint8_t                 * p_rx_secondary_buffer;
-    size_t                    tx_buffer_length;
+    volatile size_t           tx_buffer_length;
     size_t                    rx_buffer_length;
     size_t                    rx_secondary_buffer_length;
     volatile size_t           tx_counter;


### PR DESCRIPTION
This patch declares the member tx_buffer_length of uart_control_block_t
to be a volatile variable. This variable might be set/read by main thread
and also cleared by IRQ context, which might lead to unexpected behaviour
when compiling with high optimization level (LTO + O3).