### PR TITLE
nrfx_wdt: Fix reload value calculation overflow for large values

### DIFF
--- a/drivers/src/nrfx_wdt.c
+++ b/drivers/src/nrfx_wdt.c
@@ -87,7 +87,10 @@ nrfx_err_t nrfx_wdt_init(nrfx_wdt_config_t const * p_config,
 
     nrf_wdt_behaviour_set(p_config->behaviour);
 
-    nrf_wdt_reload_value_set((p_config->reload_value * 32768) / 1000);
+    uint64_t ticks = (p_config->reload_value * 32768ULL) / 1000;
+    NRFX_ASSERT(ticks <= UINT32_MAX);
+
+    nrf_wdt_reload_value_set((uint32_t) ticks);
 
 #if !NRFX_CHECK(NRFX_WDT_CONFIG_NO_IRQ)
     NRFX_IRQ_PRIORITY_SET(WDT_IRQn, p_config->interrupt_priority);


### PR DESCRIPTION
Attempting to call `nrfx_wdt_init` with a `reload_value` over that of 131072 will cause a `uint32_t` overflow causing the `reload_value` to be set much lower then intended.

Promoting this calculation to a `uint64_t` resolves this issue

For what it's worth I think `reload_value` should be renamed to `reload_value_ms` to make its use more obvious as at glance one would assume this directly sets `NRF_WDT->CRV`