### PR TITLE
nrfx_uarte: Disable shortcuts on uninit

### DIFF
--- a/drivers/src/nrfx_uarte.c
+++ b/drivers/src/nrfx_uarte.c
@@ -260,6 +260,10 @@ void nrfx_uarte_uninit(nrfx_uarte_t const * p_instance)
 {
     uarte_control_block_t * p_cb = &m_cb[p_instance->drv_inst_idx];
 
+    #define DISABLE_ALL UINT32_MAX
+    nrf_uarte_shorts_disable(p_instance->p_reg, DISABLE_ALL);
+    #undef DISABLE_ALL
+
     nrf_uarte_disable(p_instance->p_reg);
 
     if (p_cb->handler)


### PR DESCRIPTION
Shortcuts are not currently disabled on uninit. This causes higher power consumption if they were enabled