### PR TITLE
Add "ax" flags to gcc startup vector section. see: http://infocenter.…

### DIFF
--- a/mdk/gcc_startup_nrf51.S
+++ b/mdk/gcc_startup_nrf51.S
@@ -68,7 +68,7 @@ __HeapBase:
 __HeapLimit:
     .size __HeapLimit, . - __HeapLimit
 
-    .section .isr_vector
+    .section .isr_vector,"ax" /* "ax" flags needed when putting isr_vectors in a own linker output section not beeing .text */
     .align 2
     .globl __isr_vector
 __isr_vector:

--- a/mdk/gcc_startup_nrf52.S
+++ b/mdk/gcc_startup_nrf52.S
@@ -68,7 +68,7 @@ __HeapBase:
 __HeapLimit:
     .size __HeapLimit, . - __HeapLimit
 
-    .section .isr_vector
+    .section .isr_vector,"ax" /* "ax" flags needed when putting isr_vectors in a own linker output section not beeing .text */
     .align 2
     .globl __isr_vector
 __isr_vector:

--- a/mdk/gcc_startup_nrf52810.S
+++ b/mdk/gcc_startup_nrf52810.S
@@ -68,7 +68,7 @@ __HeapBase:
 __HeapLimit:
     .size __HeapLimit, . - __HeapLimit
 
-    .section .isr_vector
+    .section .isr_vector,"ax" /* "ax" flags needed when putting isr_vectors in a own linker output section not beeing .text */
     .align 2
     .globl __isr_vector
 __isr_vector:

--- a/mdk/gcc_startup_nrf52811.S
+++ b/mdk/gcc_startup_nrf52811.S
@@ -68,7 +68,7 @@ __HeapBase:
 __HeapLimit:
     .size __HeapLimit, . - __HeapLimit
 
-    .section .isr_vector
+    .section .isr_vector,"ax" /* "ax" flags needed when putting isr_vectors in a own linker output section not beeing .text */
     .align 2
     .globl __isr_vector
 __isr_vector:

--- a/mdk/gcc_startup_nrf52840.S
+++ b/mdk/gcc_startup_nrf52840.S
@@ -68,7 +68,7 @@ __HeapBase:
 __HeapLimit:
     .size __HeapLimit, . - __HeapLimit
 
-    .section .isr_vector
+    .section .isr_vector,"ax" /* "ax" flags needed when putting isr_vectors in a own linker output section not beeing .text */
     .align 2
     .globl __isr_vector
 __isr_vector:

--- a/mdk/gcc_startup_nrf9160.S
+++ b/mdk/gcc_startup_nrf9160.S
@@ -68,7 +68,7 @@ __HeapBase:
 __HeapLimit:
     .size __HeapLimit, . - __HeapLimit
 
-    .section .isr_vector
+    .section .isr_vector,"ax" /* "ax" flags needed when putting isr_vectors in a own linker output section not beeing .text */
     .align 2
     .globl __isr_vector
 __isr_vector:


### PR DESCRIPTION
 This allows to put the vector section a separate linker output section different to .text. 
 This may be usefull if for example for secure gateway veneer function should be placed on a constant flash position before size changing .text data. 

http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0742h/nqb1493039639801.html

The arm startup code does this via "AREA" command.

Example linker script:

```
ENTRY(Reset_Handler)
SECTIONS
{
    .vectors : {
       __vectors_start = .;
       KEEP(*(.isr_vector))
       __vectors_end = .;
    } > FLASH

    /* Trustzone veener functions this memory region must be marked as non-secure-callable by secure firmware init code */
    .gnu.sgstubs :
    {
      __sg_veneers_start = .;
      KEEP(*(.gnu.sgstubs*))
     } > FLASH
     __sg_veneers_end = .;

    .text :
    {
        *(.text*)
        KEEP(*(.init))
        KEEP(*(.fini))
.....
```