### PR TITLE
nrfx_pwm: Make possible to skip GPIO configuration in nrfx_pwm_init()

### DIFF
--- a/drivers/include/nrfx_pwm.h
+++ b/drivers/include/nrfx_pwm.h
@@ -100,6 +100,10 @@ typedef struct
     uint16_t           top_value;    ///< Value up to which the pulse generator counter counts.
     nrf_pwm_dec_load_t load_mode;    ///< Mode of loading sequence data from RAM.
     nrf_pwm_dec_step_t step_mode;    ///< Mode of advancing the active sequence.
+    bool               skip_gpio_cfg; ///< Skip the GPIO configuration
+                                      /**< When this flag is set, the user is responsible for
+                                       *   providing the proper configuration of the output pins,
+                                       *   as the driver does not touch it at all. */
 } nrfx_pwm_config_t;
 
 /**
@@ -130,6 +134,7 @@ typedef struct
     .top_value    = 1000,                                        \
     .load_mode    = NRF_PWM_LOAD_COMMON,                         \
     .step_mode    = NRF_PWM_STEP_AUTO,                           \
+    .skip_gpio_cfg = false                                       \
 }
 
 /** @brief PWM flags providing additional playback options. */

--- a/drivers/src/nrfx_pwm.c
+++ b/drivers/src/nrfx_pwm.c
@@ -92,16 +92,19 @@ static void configure_pins(nrfx_pwm_t const *        p_instance,
             bool inverted = output_pin &  NRFX_PWM_PIN_INVERTED;
             out_pins[i]   = output_pin & ~NRFX_PWM_PIN_INVERTED;
 
-            if (inverted)
+            if (!p_config->skip_gpio_cfg)
             {
-                nrf_gpio_pin_set(out_pins[i]);
-            }
-            else
-            {
-                nrf_gpio_pin_clear(out_pins[i]);
-            }
+               if (inverted)
+               {
+                   nrf_gpio_pin_set(out_pins[i]);
+               }
+               else
+               {
+                   nrf_gpio_pin_clear(out_pins[i]);
+               }
 
-            nrf_gpio_cfg_output(out_pins[i]);
+               nrf_gpio_cfg_output(out_pins[i]);
+            }
         }
         else
         {


### PR DESCRIPTION
We need to configure gpio pins differently from its default values while initiate pwm and pwm doesn't allow us. The new macro is added so that a user can configure the pins before invoking nrfx_init_pwm if NRFX_PWM_USER_CONFIG_GPIO is set to non-zero.