### PR TITLE
drivers: Cast `uint32_t` arguments to `unsigned long` in log messages

### DIFF
--- a/drivers/src/nrfx_rtc.c
+++ b/drivers/src/nrfx_rtc.c
@@ -157,7 +157,9 @@ nrfx_err_t nrfx_rtc_cc_disable(nrfx_rtc_t const * p_instance, uint32_t channel)
             return err_code;
         }
     }
-    NRFX_LOG_INFO("RTC id: %d, channel disabled: %lu.", p_instance->instance_id, channel);
+    NRFX_LOG_INFO("RTC id: %d, channel disabled: %lu.",
+                  p_instance->instance_id,
+                  (unsigned long)channel);
     err_code = NRFX_SUCCESS;
     NRFX_LOG_INFO("Function: %s, error code: %s.", __func__, NRFX_LOG_ERROR_STRING_GET(err_code));
     return err_code;
@@ -211,8 +213,8 @@ nrfx_err_t nrfx_rtc_cc_set(nrfx_rtc_t const * p_instance,
 
     NRFX_LOG_INFO("RTC id: %d, channel enabled: %lu, compare value: %lu.",
                   p_instance->instance_id,
-                  channel,
-                  val);
+                  (unsigned long)channel,
+                  (unsigned long)val);
     err_code = NRFX_SUCCESS;
     NRFX_LOG_INFO("Function: %s, error code: %s.", __func__, NRFX_LOG_ERROR_STRING_GET(err_code));
     return err_code;
@@ -290,7 +292,9 @@ static void irq_handler(NRF_RTC_Type * p_reg,
             nrf_rtc_event_disable(p_reg, int_mask);
             nrf_rtc_int_disable(p_reg, int_mask);
             nrf_rtc_event_clear(p_reg, event);
-            NRFX_LOG_DEBUG("Event: %s, instance id: %lu.", EVT_TO_STR(event), instance_id);
+            NRFX_LOG_DEBUG("Event: %s, instance id: %lu.",
+                           EVT_TO_STR(event),
+                           (unsigned long)instance_id);
             m_handlers[instance_id]((nrfx_rtc_int_type_t)i);
         }
         int_mask <<= 1;
@@ -301,7 +305,9 @@ static void irq_handler(NRF_RTC_Type * p_reg,
     if (nrf_rtc_int_enable_check(p_reg, NRF_RTC_INT_TICK_MASK) && nrf_rtc_event_check(p_reg, event))
     {
         nrf_rtc_event_clear(p_reg, event);
-        NRFX_LOG_DEBUG("Event: %s, instance id: %lu.", EVT_TO_STR(event), instance_id);
+        NRFX_LOG_DEBUG("Event: %s, instance id: %lu.",
+                       EVT_TO_STR(event),
+                       (unsigned long)instance_id);
         m_handlers[instance_id](NRFX_RTC_INT_TICK);
     }
 
@@ -310,7 +316,9 @@ static void irq_handler(NRF_RTC_Type * p_reg,
         nrf_rtc_event_check(p_reg, event))
     {
         nrf_rtc_event_clear(p_reg, event);
-        NRFX_LOG_DEBUG("Event: %s, instance id: %lu.", EVT_TO_STR(event), instance_id);
+        NRFX_LOG_DEBUG("Event: %s, instance id: %lu.",
+                       EVT_TO_STR(event),
+                       (unsigned long)instance_id);
         m_handlers[instance_id](NRFX_RTC_INT_OVERFLOW);
     }
 }

--- a/drivers/src/nrfx_timer.c
+++ b/drivers/src/nrfx_timer.c
@@ -226,7 +226,7 @@ void nrfx_timer_compare(nrfx_timer_t const *   p_instance,
     nrf_timer_cc_set(p_instance->p_reg, cc_channel, cc_value);
     NRFX_LOG_INFO("Timer id: %d, capture value set: %lu, channel: %d.",
                   p_instance->instance_id,
-                  cc_value,
+                  (unsigned long)cc_value,
                   cc_channel);
 }
 
@@ -248,7 +248,7 @@ void nrfx_timer_extended_compare(nrfx_timer_t const *   p_instance,
                        enable_int);
     NRFX_LOG_INFO("Timer id: %d, capture value set: %lu, channel: %d.",
                   p_instance->instance_id,
-                  cc_value,
+                  (unsigned long)cc_value,
                   cc_channel);
 }
 


### PR DESCRIPTION
To avoid warnings about providing an argument of type `uint32_t` (which
is `unsigned int`) where a `long unsigned int` one is expected.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>