### PR TITLE
NVMC improvements for UICR/OTP

### DIFF
--- a/drivers/include/nrfx_nvmc.h
+++ b/drivers/include/nrfx_nvmc.h
@@ -155,6 +155,37 @@ bool nrfx_nvmc_byte_writable_check(uint32_t address, uint8_t value);
 void nrfx_nvmc_byte_write(uint32_t address, uint8_t value);
 
 /**
+ * @brief Function for checking whether a halfword is writable at the specified address.
+ *
+ * The NVMC is only able to write '0' to bits in the Flash that are erased (set to '1').
+ * It cannot rewrite a bit back to '1'. This function checks if the value currently
+ * residing at the specified address can be transformed to the desired value
+ * without any '0' to '1' transitions.
+ *
+ * @param address Address to be checked. Must be halfword-aligned.
+ * @param value   Value to be checked.
+ *
+ * @retval true  Word can be written at the specified address.
+ * @retval false Word cannot be written at the specified address.
+ *               Erase page or change address.
+ */
+bool nrfx_nvmc_halfword_writable_check(uint32_t address, uint16_t value);
+
+/**
+ * @brief Function for writing a 16-bit halfword to flash.
+ *
+ * To determine if the flash write has been completed, use @ref nrfx_nvmc_write_done_check().
+ *
+ * @note Depending on the source of the code being executed,
+ *       the CPU may be halted during the operation.
+ *       Refer to the Product Specification for more information.
+ *
+ * @param address Address to write to. Must be halfword-aligned.
+ * @param value   Value to write.
+ */
+void nrfx_nvmc_halfword_write(uint32_t address, uint16_t value);
+
+/**
  * @brief Function for checking whether a word is writable at the specified address.
  *
  * The NVMC is only able to write '0' to bits in the Flash that are erased (set to '1').
@@ -214,6 +245,18 @@ void nrfx_nvmc_bytes_write(uint32_t address, void const * src, uint32_t num_byte
  * @param num_words Number of words to write.
  */
 void nrfx_nvmc_words_write(uint32_t address, void const * src, uint32_t num_words);
+
+/**
+ * @brief Function for reading a 16-bit aligned halfword from the OTP (UICR)
+ *
+ * OTP is a region of UICR present in some chips. This must be used since
+ * unaligned accesses are not supported on the OTP flash area.
+ *
+ * @param address   Address to read from. Must be halfword-aligned.
+ *
+ * @retval The contents at @p address.
+ */
+uint16_t nrfx_nvmc_otp_halfword_read(uint32_t address);
 
 /**
  * @brief Function for getting the total flash size in bytes.

--- a/drivers/src/nrfx_nvmc.c
+++ b/drivers/src/nrfx_nvmc.c
@@ -218,7 +218,8 @@ static void nvmc_words_write(uint32_t addr, void const * src, uint32_t num_words
 
 nrfx_err_t nrfx_nvmc_page_erase(uint32_t addr)
 {
-    NRFX_ASSERT((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get());
+    NRFX_ASSERT(((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get()) ||
+                ((addr - (uint32_t)NRF_UICR) < sizeof(NRF_UICR_Type)));
 
     if (!is_page_aligned_check(addr))
     {
@@ -260,7 +261,8 @@ void nrfx_nvmc_all_erase(void)
 #if defined(NRF_NVMC_PARTIAL_ERASE_PRESENT)
 nrfx_err_t nrfx_nvmc_page_partial_erase_init(uint32_t addr, uint32_t duration_ms)
 {
-    NRFX_ASSERT((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get());
+    NRFX_ASSERT(((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get()) ||
+                ((addr - (uint32_t)NRF_UICR) < sizeof(NRF_UICR_Type)));
 
     if (!is_page_aligned_check(addr))
     {
@@ -306,7 +308,8 @@ bool nrfx_nvmc_page_partial_erase_continue(void)
 
 bool nrfx_nvmc_byte_writable_check(uint32_t addr, uint8_t val_to_check)
 {
-    NRFX_ASSERT((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get());
+    NRFX_ASSERT(((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get()) ||
+                ((addr - (uint32_t)NRF_UICR) < sizeof(NRF_UICR_Type)));
 
     uint8_t val_on_addr = *(uint8_t const *)addr;
     return (val_to_check & val_on_addr) == val_to_check;
@@ -314,7 +317,8 @@ bool nrfx_nvmc_byte_writable_check(uint32_t addr, uint8_t val_to_check)
 
 bool nrfx_nvmc_word_writable_check(uint32_t addr, uint32_t val_to_check)
 {
-    NRFX_ASSERT((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get());
+    NRFX_ASSERT(((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get()) ||
+                ((addr - (uint32_t)NRF_UICR) < sizeof(NRF_UICR_Type)));
     NRFX_ASSERT(nrfx_is_word_aligned((void const *)addr));
 
     uint32_t val_on_addr = *(uint32_t const *)addr;
@@ -323,6 +327,9 @@ bool nrfx_nvmc_word_writable_check(uint32_t addr, uint32_t val_to_check)
 
 void nrfx_nvmc_byte_write(uint32_t addr, uint8_t value)
 {
+    NRFX_ASSERT(((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get()) ||
+                ((addr - (uint32_t)NRF_UICR) < sizeof(NRF_UICR_Type)));
+
     uint32_t aligned_addr = addr & ~(0x03UL);
 
     nrfx_nvmc_word_write(aligned_addr, partial_word_create(addr, &value, 1));
@@ -330,7 +337,8 @@ void nrfx_nvmc_byte_write(uint32_t addr, uint8_t value)
 
 void nrfx_nvmc_word_write(uint32_t addr, uint32_t value)
 {
-    NRFX_ASSERT((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get());
+    NRFX_ASSERT(((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get()) ||
+                ((addr - (uint32_t)NRF_UICR) < sizeof(NRF_UICR_Type)));
     NRFX_ASSERT(nrfx_is_word_aligned((void const *)addr));
 
     nvmc_write_mode_set();
@@ -342,7 +350,8 @@ void nrfx_nvmc_word_write(uint32_t addr, uint32_t value)
 
 void nrfx_nvmc_bytes_write(uint32_t addr, void const * src, uint32_t num_bytes)
 {
-    NRFX_ASSERT((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get());
+    NRFX_ASSERT(((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get()) ||
+                ((addr - (uint32_t)NRF_UICR) < sizeof(NRF_UICR_Type)));
 
     nvmc_write_mode_set();
 
@@ -404,7 +413,8 @@ void nrfx_nvmc_bytes_write(uint32_t addr, void const * src, uint32_t num_bytes)
 
 void nrfx_nvmc_words_write(uint32_t addr, void const * src, uint32_t num_words)
 {
-    NRFX_ASSERT((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get());
+    NRFX_ASSERT(((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get()) ||
+                ((addr - (uint32_t)NRF_UICR) < sizeof(NRF_UICR_Type)));
     NRFX_ASSERT(nrfx_is_word_aligned((void const *)addr));
     NRFX_ASSERT(nrfx_is_word_aligned(src));
 


### PR DESCRIPTION
Fix some limitations in the driver relating to the HW:

 - The assert triggers for writes to UICR, since it is outside regular flash.
 - The OTP region is centered around halfwords.

Found while working on https://github.com/NordicPlayground/fw-nrfconnect-nrf/pull/1917.