### PR TITLE
nrfx_nvmc: Fix setting of program memory access mode for secure code

### DIFF
--- a/drivers/src/nrfx_nvmc.c
+++ b/drivers/src/nrfx_nvmc.c
@@ -189,27 +189,42 @@ static uint32_t partial_word_create(uint32_t addr, uint8_t const * bytes, uint32
 
 static void nvmc_readonly_mode_set(void)
 {
-#if defined(NRF_TRUSTZONE_NONSECURE)
+    /*
+     * For secure code, the access mode needs to be set for both secure and
+     * non-secure regions.
+     */
+#if defined(NVMC_CONFIGNS_WEN_Msk)
     nrf_nvmc_nonsecure_mode_set(NRF_NVMC, NRF_NVMC_NS_MODE_READONLY);
-#else
+#endif
+#if !defined(NRF_TRUSTZONE_NONSECURE)
     nrf_nvmc_mode_set(NRF_NVMC, NRF_NVMC_MODE_READONLY);
 #endif
 }
 
 static void nvmc_write_mode_set(void)
 {
-#if defined(NRF_TRUSTZONE_NONSECURE)
+    /*
+     * For secure code, the access mode needs to be set for both secure and
+     * non-secure regions.
+     */
+#if defined(NVMC_CONFIGNS_WEN_Msk)
     nrf_nvmc_nonsecure_mode_set(NRF_NVMC, NRF_NVMC_NS_MODE_WRITE);
-#else
+#endif
+#if !defined(NRF_TRUSTZONE_NONSECURE)
     nrf_nvmc_mode_set(NRF_NVMC, NRF_NVMC_MODE_WRITE);
 #endif
 }
 
 static void nvmc_erase_mode_set(void)
 {
-#if defined(NRF_TRUSTZONE_NONSECURE)
+    /*
+     * For secure code, the access mode needs to be set for both secure and
+     * non-secure regions.
+     */
+#if defined(NVMC_CONFIGNS_WEN_Msk)
     nrf_nvmc_nonsecure_mode_set(NRF_NVMC, NRF_NVMC_NS_MODE_ERASE);
-#else
+#endif
+#if !defined(NRF_TRUSTZONE_NONSECURE)
     nrf_nvmc_mode_set(NRF_NVMC, NRF_NVMC_MODE_ERASE);
 #endif
 }


### PR DESCRIPTION
For secure code, the access mode needs to be set for both secure and
non-secure regions. Otherwise, attempts from secure code to write or
erase a region configured as non-secure end up with BusFault.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>