### PR TITLE
add support for skip_gpio_setup on GPIOTE out channels

### DIFF
--- a/drivers/include/nrfx_gpiote.h
+++ b/drivers/include/nrfx_gpiote.h
@@ -145,6 +145,7 @@ typedef struct
     nrf_gpiote_polarity_t action;     /**< Configuration of the pin task. */
     nrf_gpiote_outinit_t  init_state; /**< Initial state of the output pin. */
     bool                  task_pin;   /**< True if the pin is controlled by a GPIOTE task. */
+    bool                  skip_gpio_setup; /**< Do not change GPIO configuration */
 } nrfx_gpiote_out_config_t;
 
 /** @brief Macro for configuring a pin to use as output. GPIOTE is not used for the pin. */

--- a/drivers/src/nrfx_gpiote.c
+++ b/drivers/src/nrfx_gpiote.c
@@ -434,17 +434,19 @@ static nrfx_err_t gpiote_out_init(nrfx_gpiote_pin_t                pin,
 
         if (err_code == NRFX_SUCCESS)
         {
-            if (p_config->init_state == NRF_GPIOTE_INITIAL_VALUE_HIGH)
-            {
-                nrf_gpio_pin_set(pin);
-            }
-            else
-            {
-                nrf_gpio_pin_clear(pin);
-            }
+            if(!p_config->skip_gpio_setup) {
+                if (p_config->init_state == NRF_GPIOTE_INITIAL_VALUE_HIGH)
+                {
+                    nrf_gpio_pin_set(pin);
+                }
+                else
+                {
+                    nrf_gpio_pin_clear(pin);
+                }
 
-            nrf_gpio_cfg_output(pin);
-            pin_configured_set(pin);
+                nrf_gpio_cfg_output(pin);
+                pin_configured_set(pin);
+            }
         }
     }
 


### PR DESCRIPTION

This is needed for use cases where resetting the output pin configuration via nrfx_gpiote_out_uninit is not acceptable, e.g. when used as open-drain with pull-up.
