### PR TITLE
drivers: nrfx_{twi, twim}: Fix busy flag not reset

### DIFF
--- a/drivers/src/nrfx_twi.c
+++ b/drivers/src/nrfx_twi.c
@@ -274,6 +274,7 @@ void nrfx_twi_disable(nrfx_twi_t const * p_instance)
     nrf_twi_disable(p_twi);
 
     p_cb->state = NRFX_DRV_STATE_INITIALIZED;
+    p_cb->busy = false;
     NRFX_LOG_INFO("Instance disabled: %d.", p_instance->drv_inst_idx);
 }
 

--- a/drivers/src/nrfx_twim.c
+++ b/drivers/src/nrfx_twim.c
@@ -343,6 +343,7 @@ void nrfx_twim_disable(nrfx_twim_t const * p_instance)
     nrf_twim_disable(p_twim);
 
     p_cb->state = NRFX_DRV_STATE_INITIALIZED;
+    p_cb->busy = false;
     NRFX_LOG_INFO("Instance disabled: %d.", p_instance->drv_inst_idx);
 }
 


### PR DESCRIPTION
This is necessary so that next occurence of nrfx_{twi, twim}_enable()
followed by {twi, twim}_xfer() will not raised a NRFX_ERROR_BUSY error.

This could happen when a previous transfer is started but is aborted
using nrfx_{twi, twim}_disable() before the end of the transaction which
calls {twi, twim}_irq_handler().

Signed-off-by: Xavier Chapron <xavier.chapron@stimio.fr>