### PR TITLE
nrfx_dppi: Fix variable used in logging function

### DIFF
--- a/drivers/src/nrfx_dppi.c
+++ b/drivers/src/nrfx_dppi.c
@@ -130,7 +130,7 @@ nrfx_err_t nrfx_dppi_channel_alloc(uint8_t * p_channel)
 
     if (err_code == NRFX_SUCCESS)
     {
-        NRFX_LOG_INFO("Allocated channel: %d.", channel);
+        NRFX_LOG_INFO("Allocated channel: %d.", *p_channel);
     }
     else
     {


### PR DESCRIPTION
Depending on the implementation of NRFX_CRITICAL_SECTION_ENTER
the 'channel' variable could be undefined in logging function.

Signed-off-by: Nikodem Kastelik <nikodem.kastelik@nordicsemi.no>