### PR TITLE
nrfx_pwm: Fix incorrect check that suppresses pin configuration

### DIFF
--- a/drivers/src/nrfx_pwm.c
+++ b/drivers/src/nrfx_pwm.c
@@ -86,7 +86,7 @@ static void configure_pins(nrfx_pwm_t const *        p_instance,
 {
     // Nothing to do here if both GPIO configuration and pin selection are
     // to be skipped (the pin numbers may be then even not specified).
-    if (!(p_config->skip_gpio_cfg && p_config->skip_psel_cfg))
+    if (p_config->skip_gpio_cfg && p_config->skip_psel_cfg)
     {
         return;
     }


### PR DESCRIPTION
The whole pin configuration function in the driver should be skipped
when both GPIO and PSEL skip flags are set, but the code that checks
this condition, despite the comment correctly explaining its purpose,
contains an unwanted negation. This commit fixes this embarrassing
copy-paste mistake.

Mirrored https://github.com/zephyrproject-rtos/hal_nordic/pull/109.