### PR TITLE
nfct: Improve support for various NFC protocols

### DIFF
--- a/drivers/include/nrfx_nfct.h
+++ b/drivers/include/nrfx_nfct.h
@@ -240,6 +240,20 @@ nrfx_err_t nrfx_nfct_tx(nrfx_nfct_data_desc_t const * p_tx_data,
                         nrf_nfct_frame_delay_mode_t   delay_mode);
 
 /**
+ * @brief Function for transmitting an NFC frame with a specified number of bits.
+ *
+ * @param[in] p_tx_data   Pointer to the TX buffer. Unlike in @ref nrfx_nfct_tx, @p data_size is
+ *                        used as the number of bits to transmit, rather than bytes.
+ * @param[in] delay_mode  Delay mode of the NFCT frame timer.
+ *
+ * @retval NRFX_SUCCESS              The operation was successful.
+ * @retval NRFX_ERROR_INVALID_LENGTH The TX buffer size is invalid.
+ * @retval NRFX_ERROR_BUSY           Driver is already transferring.
+ */
+nrfx_err_t nrfx_nfct_bits_tx(nrfx_nfct_data_desc_t const * p_tx_data,
+                             nrf_nfct_frame_delay_mode_t   delay_mode);
+
+/**
  * @brief Function for moving the NFCT to a new state.
  *
  * @note  The HFCLK must be running before activating the NFCT with

--- a/drivers/src/nrfx_nfct.c
+++ b/drivers/src/nrfx_nfct.c
@@ -556,6 +556,62 @@ nrfx_err_t nrfx_nfct_tx(nrfx_nfct_data_desc_t const * p_tx_data,
     return err;
 }
 
+nrfx_err_t nrfx_nfct_bits_tx(nrfx_nfct_data_desc_t const * p_tx_data,
+                             nrf_nfct_frame_delay_mode_t   delay_mode)
+{
+    NRFX_ASSERT(p_tx_data);
+    NRFX_ASSERT(p_tx_data->p_data);
+
+    nrfx_err_t err = NRFX_SUCCESS;
+
+    if (p_tx_data->data_size == 0)
+    {
+        return NRFX_ERROR_INVALID_LENGTH;
+    }
+
+    /* Get buffer length, add additional byte if bits go beyond last whole byte */
+    uint32_t buffer_length = NRFX_NFCT_BITS_TO_BYTES(p_tx_data->data_size);
+    if (p_tx_data->data_size & NFCT_TXD_AMOUNT_TXDATABITS_Msk)
+    {
+        ++buffer_length;
+    }
+
+    NRFX_CRITICAL_SECTION_ENTER();
+
+    /* In case when NFC frame transmission has already started, it returns an error. */
+    if (NRFX_NFCT_EVT_ACTIVE(TXFRAMESTART))
+    {
+        err = NRFX_ERROR_BUSY;
+    }
+    else
+    {
+        /* In case when Tx operation was scheduled with delay, stop scheduled Tx operation. */
+#if defined(NRF52_SERIES)
+        *(volatile uint32_t *)0x40005010 = 0x01;
+#elif defined(NRF5340_XXAA_APPLICATION) && defined(NRF_TRUSTZONE_NONSECURE)
+        *(volatile uint32_t *)0x4002D010 = 0x01;
+#elif defined(NRF5340_XXAA_APPLICATION)
+        *(volatile uint32_t *)0x5002D010 = 0x01;
+#endif
+        nrf_nfct_rxtx_buffer_set(NRF_NFCT, (uint8_t *) p_tx_data->p_data, buffer_length);
+        nrf_nfct_tx_bits_set(NRF_NFCT, p_tx_data->data_size);
+        nrf_nfct_frame_delay_mode_set(NRF_NFCT, (nrf_nfct_frame_delay_mode_t) delay_mode);
+        nrfx_nfct_frame_delay_max_set(false);
+
+        nrfx_nfct_rxtx_int_enable(NRFX_NFCT_TX_INT_MASK);
+        nrf_nfct_task_trigger(NRF_NFCT, NRF_NFCT_TASK_STARTTX);
+    }
+
+    NRFX_CRITICAL_SECTION_EXIT();
+
+    if (err == NRFX_SUCCESS)
+    {
+        NRFX_LOG_INFO("Tx start");
+    }
+
+    return err;
+}
+
 void nrfx_nfct_state_force(nrfx_nfct_state_t state)
 {
 #if NRFX_CHECK(USE_WORKAROUND_FOR_ANOMALY_190)

--- a/drivers/src/nrfx_nfct.c
+++ b/drivers/src/nrfx_nfct.c
@@ -794,6 +794,18 @@ void nrfx_nfct_irq_handler(void)
         nrfx_nfct_field_event_handler(current_field);
     }
 
+    if (NRFX_NFCT_EVT_ACTIVE(RXFRAMESTART))
+    {
+        nrf_nfct_event_clear(NRF_NFCT, NRF_NFCT_EVENT_RXFRAMESTART);
+
+        nrfx_nfct_evt_t nfct_evt =
+        {
+            .evt_id = NRFX_NFCT_EVT_RX_FRAMESTART
+        };
+
+        NRFX_NFCT_CB_HANDLE(m_nfct_cb.config.cb, nfct_evt);
+    }
+
     if (NRFX_NFCT_EVT_ACTIVE(RXFRAMEEND))
     {
         nrf_nfct_event_clear(NRF_NFCT, NRF_NFCT_EVENT_RXFRAMEEND);

--- a/hal/nrf_nfct.h
+++ b/hal/nrf_nfct.h
@@ -881,6 +881,27 @@ nrf_nfct_selres_protocol_t nrf_nfct_selres_protocol_get(NRF_NFCT_Type const * p_
 NRF_STATIC_INLINE void nrf_nfct_selres_protocol_set(NRF_NFCT_Type *            p_reg,
                                                     nrf_nfct_selres_protocol_t sel_res_protocol);
 
+/**
+ * @brief Function for getting the SEL_RES frame configuration.
+ *
+ * @details The SEL_RES frame is handled automatically by the NFCT hardware.
+ *
+ * @param[in] p_reg Pointer to the structure of registers of the peripheral.
+ *
+ * @return SEL_RES frame configuration.
+ */
+NRF_STATIC_INLINE uint32_t nrf_nfct_selres_get(NRF_NFCT_Type const * p_reg);
+
+/**
+ * @brief Function for setting the SEL_RES frame configuration.
+ *
+ * @details The SEL_RES frame is handled automatically by the NFCT hardware.
+ *
+ * @param[in] p_reg  Pointer to the structure of registers of the peripheral.
+ * @param[in] selres SEL_RES frame configuration.
+ */
+NRF_STATIC_INLINE void nrf_nfct_selres_set(NRF_NFCT_Type * p_reg, uint32_t selres);
+
 #ifndef NRF_DECLARE_ONLY
 NRF_STATIC_INLINE void nrf_nfct_task_trigger(NRF_NFCT_Type * p_reg, nrf_nfct_task_t task)
 {
@@ -1259,6 +1280,16 @@ NRF_STATIC_INLINE void nrf_nfct_selres_protocol_set(NRF_NFCT_Type *            p
 {
     p_reg->SELRES = (p_reg->SELRES & ~NFCT_SELRES_PROTOCOL_Msk) |
                     ((uint32_t)sel_res_protocol << NFCT_SELRES_PROTOCOL_Pos);
+}
+
+NRF_STATIC_INLINE uint32_t nrf_nfct_selres_get(NRF_NFCT_Type const * p_reg)
+{
+    return p_reg->SELRES;
+}
+
+NRF_STATIC_INLINE void nrf_nfct_selres_set(NRF_NFCT_Type * p_reg, uint32_t selres)
+{
+    p_reg->SELRES = (p_reg->SELRES & NFCT_SELRES_CASCADE_Msk) | (selres & ~NFCT_SELRES_CASCADE_Msk);
 }
 #endif /* NRF_DECLARE_ONLY */
 

--- a/hal/nrf_nfct.h
+++ b/hal/nrf_nfct.h
@@ -248,13 +248,6 @@ typedef enum
     NRF_NFCT_SENSRES_PLATFORM_CONFIG_OTHER = 0 << NFCT_SENSRES_PLATFCONFIG_Pos
 } nrf_nfct_sensres_platform_config_t;
 
-/** @brief Bit masks for SEL_RES NFC frame configuration. */
-typedef enum
-{
-    NRF_NFCT_SELRES_CASCADE_MASK  = NFCT_SELRES_CASCADE_Msk,  /**< SEL_RES Cascade field bit mask. */
-    NRF_NFCT_SELRES_PROTOCOL_MASK = NFCT_SELRES_PROTOCOL_Msk  /**< SEL_RES Protocol field bit mask. */
-} nrf_nfct_selres_t;
-
 /**
  * @brief Protocol NFC field (bits b7 and b6) configuration for the SEL_RES frame according to
  *        the NFC Forum Digital Protocol Technical Specification.


### PR DESCRIPTION
This is a combination of some changes done by nitz in PR:s #79 and #78 that haven't been merged in over a year, so I am trying to get them merged here instead.

I have also added some functions to get/set RFU bits of the SELRES register, which is required by some NFC protocols.