### PR TITLE
NVMC changes for simulation

### DIFF
--- a/drivers/include/nrfx_nvmc.h
+++ b/drivers/include/nrfx_nvmc.h
@@ -328,7 +328,7 @@ NRFX_STATIC_INLINE bool nrfx_nvmc_write_done_check(void)
 
 NRFX_STATIC_INLINE uint32_t nrfx_nvmc_uicr_word_read(uint32_t const volatile *address)
 {
-    uint32_t value = *address;
+    uint32_t value = nrf_nvmc_word_read((uint32_t)address);
 
 #if NRF91_ERRATA_7_ENABLE_WORKAROUND
     __DSB();

--- a/drivers/nrfx_common.h
+++ b/drivers/nrfx_common.h
@@ -37,6 +37,7 @@
 #include <stdint.h>
 #include <stddef.h>
 #include <stdbool.h>
+#include <string.h>
 #include <limits.h>
 
 #include <nrf.h>

--- a/drivers/src/nrfx_nvmc.c
+++ b/drivers/src/nrfx_nvmc.c
@@ -246,7 +246,7 @@ static void nvmc_word_write(uint32_t addr, uint32_t value)
     {}
 #endif
 
-    *(volatile uint32_t *)addr = value;
+    nrf_nvmc_word_write(addr, value);
     __DMB();
 }
 
@@ -350,7 +350,7 @@ bool nrfx_nvmc_byte_writable_check(uint32_t addr, uint8_t val_to_check)
 {
     NRFX_ASSERT(is_valid_address(addr, true));
 
-    uint8_t val_on_addr = *(uint8_t const *)addr;
+    uint8_t val_on_addr = nrf_nvmc_byte_read(addr);
     return (val_to_check & val_on_addr) == val_to_check;
 }
 
@@ -363,7 +363,7 @@ bool nrfx_nvmc_halfword_writable_check(uint32_t addr, uint16_t val_to_check)
 
     if ((addr - NVMC_FLASH_BASE_ADDRESS) < flash_total_size_get())
     {
-        val_on_addr = *(uint16_t const *)addr;
+        val_on_addr = nrf_nvmc_halfword_read(addr);
     }
     else
     {
@@ -377,7 +377,7 @@ bool nrfx_nvmc_word_writable_check(uint32_t addr, uint32_t val_to_check)
     NRFX_ASSERT(is_valid_address(addr, true));
     NRFX_ASSERT(nrfx_is_word_aligned((void const *)addr));
 
-    uint32_t val_on_addr = *(uint32_t const *)addr;
+    uint32_t val_on_addr = nrf_nvmc_word_read(addr);
     return (val_to_check & val_on_addr) == val_to_check;
 }
 
@@ -492,7 +492,7 @@ uint16_t nrfx_nvmc_otp_halfword_read(uint32_t addr)
     NRFX_ASSERT(is_halfword_aligned(addr));
 
     uint32_t aligned_addr = addr & ~(0x03UL);
-    uint32_t val32 = *(const uint32_t *)aligned_addr;
+    uint32_t val32 = nrf_nvmc_word_read(aligned_addr);
 
     return (nrfx_is_word_aligned((void const *)addr) ? (uint16_t)(val32)
                                                      : (uint16_t)(val32 >> 16));

--- a/hal/nrf_nvmc.h
+++ b/hal/nrf_nvmc.h
@@ -134,6 +134,79 @@ NRF_STATIC_INLINE void nrf_nvmc_nonsecure_mode_set(NRF_NVMC_Type *    p_reg,
 #endif
 
 /**
+ * @brief Function for writing a 32-bit word to flash.
+ *
+ * @note Before calling this function, the caller must ensure that:
+ *     - the @p address is word-aligned,
+ *     - write mode is enabled, using @ref nrf_nvmc_mode_set,
+ *     - the NVMC is ready to accept another write, using
+ *       @ref nrf_nvmc_ready_check or @ref nrf_nvmc_write_ready_check,
+ *     - read-only mode is enabled as soon as writing is no longer needed,
+ *       using @ref nrf_nvmc_mode_set.
+ *
+ * @warning It is recommended to use @ref nrfx_nvmc_word_write function instead.
+ *
+ * Using this function when accessing the flash gives the possibility
+ * to run the code in an environment where the flash is simulated.
+ *
+ * @param[in] address  Address of the word to write.
+ * @param[in] value    Value to write.
+ */
+NRF_STATIC_INLINE void nrf_nvmc_word_write(uint32_t address,
+                                           uint32_t value);
+
+/**
+ * @brief Function for reading a byte from the flash.
+ *
+ * Using this function when accessing the flash gives the possibility
+ * to run the code in an environment where the flash is simulated.
+ *
+ * @param[in] address Address of the byte to read.
+ *
+ * @return Value read from flash.
+ */
+NRF_STATIC_INLINE uint8_t nrf_nvmc_byte_read(uint32_t address);
+
+/**
+ * @brief Function for reading a 16-bit halfword from the flash.
+ *
+ * Using this function when accessing the flash gives the possibility
+ * to run the code in an environment where the flash is simulated.
+ *
+ * @param[in] address Address of the halfword to read.
+ *
+ * @return Value read from flash.
+ */
+NRF_STATIC_INLINE uint16_t nrf_nvmc_halfword_read(uint32_t address);
+
+/**
+ * @brief Function for reading a 32-bit word from the flash.
+ *
+ * Using this function when accessing the flash gives the possibility
+ * to run the code in an environment where the flash is simulated.
+ *
+ * @param[in] address Address of the word to read.
+ *
+ * @return Value read from flash.
+ */
+NRF_STATIC_INLINE uint32_t nrf_nvmc_word_read(uint32_t address);
+
+/**
+ * @brief Function for reading a given number of bytes from the flash into the specified buffer.
+ *
+ * Using this function when accessing the flash gives the possibility
+ * to run the code in an environment where the flash is simulated.
+ *
+ * @param[in] dst       Pointer to the buffer to store the data.
+ * @param[in] address   Address of the first byte to read.
+ * @param[in] num_bytes Number of bytes to read.
+ *
+ */
+NRF_STATIC_INLINE void nrf_nvmc_buffer_read(void *   dst,
+                                            uint32_t address,
+                                            uint32_t num_bytes);
+
+/**
  * @brief Function for starting a single page erase in the Flash memory.
  *
  * The NVMC mode must be correctly configured with @ref nrf_nvmc_mode_set
@@ -281,6 +354,34 @@ NRF_STATIC_INLINE void nrf_nvmc_nonsecure_mode_set(NRF_NVMC_Type *    p_reg,
     p_reg->CONFIGNS = (uint32_t)mode;
 }
 #endif
+
+NRF_STATIC_INLINE void nrf_nvmc_word_write(uint32_t address,
+                                           uint32_t value)
+{
+    *(volatile uint32_t *)address = value;
+}
+
+NRF_STATIC_INLINE uint8_t nrf_nvmc_byte_read(uint32_t address)
+{
+    return *(volatile uint8_t *)address;
+}
+
+NRF_STATIC_INLINE uint16_t nrf_nvmc_halfword_read(uint32_t address)
+{
+    return *(volatile uint16_t *)address;
+}
+
+NRF_STATIC_INLINE uint32_t nrf_nvmc_word_read(uint32_t address)
+{
+    return *(volatile uint32_t *)address;
+}
+
+NRF_STATIC_INLINE void nrf_nvmc_buffer_read(void *   dst,
+                                            uint32_t address,
+                                            uint32_t num_bytes)
+{
+    memcpy(dst, (void *)address, num_bytes);
+}
 
 NRF_STATIC_INLINE void nrf_nvmc_page_erase_start(NRF_NVMC_Type * p_reg,
                                                  uint32_t        page_addr)


### PR DESCRIPTION
Replica of https://github.com/zephyrproject-rtos/hal_nordic/pull/132

-------

nvmc: Provide new functions to read and write to flash

For reads both for singular words and buffers,
for writes just for singular words.

---------

drivers: nvmc: Use new hal functions

Use new HAL function to write to flash
(the function is inlined and just performs the same access for real targets).
This change enables using the driver in the nrf52_bsim.
