### PR TITLE
Add max iteration limit to prevent infinite loops in nrfx_gpiote.c

### DIFF
--- a/drivers/src/nrfx_gpiote.c
+++ b/drivers/src/nrfx_gpiote.c
@@ -1563,6 +1563,9 @@ static void port_event_handle(NRF_GPIOTE_Type * p_gpiote, gpiote_control_block_t
     uint8_t rel_pin;
     nrfx_gpiote_pin_t pin;
     nrfx_gpiote_trigger_t trigger;
+    uint32_t iteration_count = 0;
+    /* Large enough margin for edge cases */
+    const uint32_t MAX_ITERATIONS = GPIO_COUNT * 32 * 3;
 
     for (uint32_t port_idx = 0; port_idx < GPIO_COUNT; port_idx++)
     {
@@ -1574,6 +1577,8 @@ static void port_event_handle(NRF_GPIOTE_Type * p_gpiote, gpiote_control_block_t
     }
 
     do {
+        iteration_count++;
+        NRFX_ASSERT(iteration_count <= MAX_ITERATIONS);
         for (uint32_t i = 0; i < GPIO_COUNT; i++)
         {
             while (pins_to_check[i])


### PR DESCRIPTION
## Description

The `input_read_and_check` can potentially never return false in case there are fluctuations introduced due to external noise, or faulty hardware. In this case, it becomes essential to ensure that the the `do-while` loop in `port_event_handle` function breaks after executing enough number of iterations which otherwise would remain stuck in an infinite loop.

## Patch

This patch adds `max_iterations` depending on the `GPIO_COUNT` and ensures that the loop breaks out in a scenario where `input_read_and_check` never returns false. Multiplying it with `32` accounts for the maximum possible number of events that could occur for each GPIO pin, based on the expected event width or number of state changes. Multiplying with `3` provides an additional margin to handle subtle fluctuations or hardware anomalies, ensuring the loop terminates in case of brief external noise or edge cases.