### PR TITLE
nrfx_timer: optimize IRQ handler in nrfx_timer

### DIFF
--- a/drivers/src/nrfx_timer.c
+++ b/drivers/src/nrfx_timer.c
@@ -359,9 +359,9 @@ void nrfx_timer_compare_int_disable(nrfx_timer_t const * p_instance, uint32_t ch
 
 static void irq_handler(NRF_TIMER_Type * p_reg, timer_control_block_t * p_cb, uint8_t channel_count)
 {
-    uint32_t event_mask = nrfy_timer_events_process(p_reg, NRF_TIMER_ALL_CHANNELS_INT_MASK);
-    nrf_timer_event_t event;
     uint32_t active_cc_mask = nrfy_timer_int_enable_check(p_reg, NRF_TIMER_ALL_CHANNELS_INT_MASK);
+    uint32_t event_mask = nrfy_timer_events_process(p_reg, active_cc_mask);
+    nrf_timer_event_t event;
 
     for (uint8_t i = 0; i < channel_count; ++i)
     {


### PR DESCRIPTION
The irq handler can look at only the CCs that have IRQs enabled This is a fairly substantial perf win on nRF54H20, as the 8ccs sitting in the 16MHz domain take 4-5us to query.

Tested via zephyr drivers counter test