### PR TITLE
nrfx: drivers: avoid using c23 unnamed parameters

### DIFF
--- a/drivers/nrfx_common.h
+++ b/drivers/nrfx_common.h
@@ -97,7 +97,7 @@ extern "C" {
 #define NRFX_RELEASE_VER_MICRO 1
 
 /** @brief IRQ handler type. */
-typedef void (* nrfx_irq_handler_t)(void *);
+typedef void (* nrfx_irq_handler_t)(void * p_context);
 
 /** @brief Driver state. */
 typedef enum

--- a/drivers/nrfx_utils.h
+++ b/drivers/nrfx_utils.h
@@ -414,7 +414,7 @@
  * @param[in] p_instance        Pointer to the driver instance object.
  */
 #define NRFX_INSTANCE_IRQ_HANDLER_DEFINE(periph_name_small, inst_idx, p_instance) \
-    void NRFX_CONCAT(nrfx_, periph_name_small, _, inst_idx, _irq_handler)(void *) \
+    void NRFX_CONCAT(nrfx_, periph_name_small, _, inst_idx, _irq_handler)(void * p_context) \
     {                                                                             \
         NRFX_CONCAT(nrfx_, periph_name_small, _irq_handler)(p_instance);          \
     }

--- a/drivers/nrfx_utils_internal.h
+++ b/drivers/nrfx_utils_internal.h
@@ -161,7 +161,7 @@
  * @param[in] periph_name_small Peripheral name in small letters, e.g. spim.
  */
 #define _NRFX_IRQ_HANDLER(periph_name, prefix, i, periph_name_small)                         \
-void NRFX_CONCAT(nrfx_, periph_name_small, _, prefix, i, _irq_handler)(void *)               \
+void NRFX_CONCAT(nrfx_, periph_name_small, _, prefix, i, _irq_handler)(void * p_context)               \
 {                                                                                            \
     irq_handler(NRFX_COND_CODE_1(NRFX_INSTANCE_PRESENT(NRFX_CONCAT(periph_name, prefix, i)), \
                                  (NRFX_CONCAT(NRF_, periph_name, prefix, i)), (NULL)),       \
@@ -183,7 +183,7 @@ void NRFX_CONCAT(nrfx_, periph_name_small, _, prefix, i, _irq_handler)(void *)  
  * @param[in] ext_macro         Macro called as third parameter of the handler.
  */
 #define _NRFX_IRQ_HANDLER_EXT(periph_name, prefix, i, periph_name_small, ext_macro) \
-void NRFX_CONCAT(nrfx_, periph_name_small, _, prefix, i, _irq_handler)(void *)      \
+void NRFX_CONCAT(nrfx_, periph_name_small, _, prefix, i, _irq_handler)(void * p_context)      \
 {                                                                                   \
     irq_handler(NRFX_CONCAT(NRF_, periph_name, prefix, i),                          \
                 &m_cb[NRFX_CONCAT(NRFX_, periph_name, prefix, i, _INST_IDX)],       \
@@ -194,7 +194,7 @@ void NRFX_CONCAT(nrfx_, periph_name_small, _, prefix, i, _irq_handler)(void *)  
     NRFX_CONCAT(nrfx_, periph_name_small, _, prefix, i, _irq_handler),
 
 #define _NRFX_IRQ_HANDLER_DECLARE(periph_name, prefix, i, periph_name_small) \
-    void NRFX_CONCAT(nrfx_, periph_name_small, _, prefix, i, _irq_handler)(void *);
+    void NRFX_CONCAT(nrfx_, periph_name_small, _, prefix, i, _irq_handler)(void * p_context);
 
 #define _PERIPH_PTR_COMPARE(periph_name, prefix, idx, reg)                       \
     ((uintptr_t)reg == (uintptr_t)NRFX_CONCAT(NRF_, periph_name, prefix, idx)) ? \


### PR DESCRIPTION
During the 4.0.0 update, many macros to generate IRQ handlers had their function signature updated to accept a pointer as parameter, which is typically used in some vector tables for passing some context.

The way it was done was leaving the parameter unnamed in the macros, which is a feature added in C23. This breaks compatibility with older C versions. My suggestion is to simply add `p_context` to keep a name for the parameter so nrfx does not complain in 
