### PR TITLE
nrfx: fix errata7 workaround in nrfx_nvmc_uicr_word_read/write

### DIFF
--- a/drivers/include/nrfx_nvmc.h
+++ b/drivers/include/nrfx_nvmc.h
@@ -370,8 +370,9 @@ NRFX_STATIC_INLINE bool nrfx_nvmc_write_done_check(void)
 NRFX_STATIC_INLINE uint32_t nrfx_nvmc_uicr_word_read(uint32_t const volatile *address)
 {
 #if NRF_ERRATA_STATIC_CHECK(91, 7)
+    const bool errata_7 = NRF_ERRATA_DYNAMIC_CHECK(91, 7);
     bool irq_disabled = __get_PRIMASK() == 1;
-    if (NRF_ERRATA_DYNAMIC_CHECK(91, 7) && !irq_disabled)
+    if (errata_7 && !irq_disabled)
     {
         __disable_irq();
     }
@@ -380,7 +381,7 @@ NRFX_STATIC_INLINE uint32_t nrfx_nvmc_uicr_word_read(uint32_t const volatile *ad
     uint32_t value = nrf_nvmc_word_read((uint32_t)address);
 
 #if NRF_ERRATA_STATIC_CHECK(91, 7)
-    if (NRF_ERRATA_DYNAMIC_CHECK(91, 7))
+    if (errata_7)
     {
         __DSB();
         if (!irq_disabled)
@@ -396,8 +397,9 @@ NRFX_STATIC_INLINE uint32_t nrfx_nvmc_uicr_word_read(uint32_t const volatile *ad
 NRFX_STATIC_INLINE void nrfx_nvmc_uicr_word_write(uint32_t volatile *address, uint32_t value)
 {
 #if NRF_ERRATA_STATIC_CHECK(91, 7)
+    const bool errata_7 = NRF_ERRATA_DYNAMIC_CHECK(91, 7);
     bool irq_disabled = __get_PRIMASK() == 1;
-    if (NRF_ERRATA_DYNAMIC_CHECK(91, 7) && !irq_disabled)
+    if (errata_7 && !irq_disabled)
     {
         __disable_irq();
     }
@@ -406,7 +408,7 @@ NRFX_STATIC_INLINE void nrfx_nvmc_uicr_word_write(uint32_t volatile *address, ui
     nrfx_nvmc_word_write((uint32_t)address, value);
 
 #if NRF_ERRATA_STATIC_CHECK(91, 7)
-    if (NRF_ERRATA_DYNAMIC_CHECK(91, 7))
+    if (errata_7)
     {
         __DSB();
         if (!irq_disabled)


### PR DESCRIPTION
The errata 7 workaround is broken in the current state, and it causes issues with NRF Connect SDK 3.2.1.

Symptom: if I read UICR via TF-M, the actual read works fine, but the next time I generate a panic, it will HardFault instead of being handled properly. 

I'm not sure specifically WHY this happens, but this patch fixes it, and seems more logically consistent with the actual errata.

Root issue:

`NRF_ERRATA_DYNAMIC_CHECK` does a flash read in `nrf91_errata_7` ( when it checks `NRF_FICR_S`) which happens before the actual memory barrier executes. 

Pull requests are a little annoying with all the different repos, so I've done the PR here and added a working sample to reproduce the issue below, hope that's fine. 

https://github.com/campbellyoung/sdk-nrf/blob/tfm-uicr-panic/samples/crypto/tfm_uicr_panic/